### PR TITLE
Set `-buildvcs=false` in the Go dependency scanning

### DIFF
--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -58,7 +58,6 @@ module LicenseFinder
         # -mod=readonly flag). Each of the imported packages gets listed separatly,
         # confusing the issue as to which package is the root of the module.
         go_list_cmd = "GO111MODULE=on go list -mod=readonly -buildvcs=false -deps -f '#{format_str}' ./..."
-        # go_list_cmd = "GO111MODULE=on go list -mod=readonly -deps -f '#{format_str}' ./..."
         info_output, stderr, status = Cmd.run(go_list_cmd)
         log_errors_with_cmd(go_list_cmd, "Getting the dependencies from go list failed \n\t#{stderr}") unless status.success?
         raise "Command '#{go_list_cmd}' failed to execute" unless status.success?

--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -57,7 +57,8 @@ module LicenseFinder
         # TODO: Figure out a way to make the vendor directory work (i.e. remove the
         # -mod=readonly flag). Each of the imported packages gets listed separatly,
         # confusing the issue as to which package is the root of the module.
-        go_list_cmd = "GO111MODULE=on go list -mod=readonly -deps -f '#{format_str}' ./..."
+        go_list_cmd = "GO111MODULE=on go list -mod=readonly -buildvcs=false -deps -f '#{format_str}' ./..."
+        # go_list_cmd = "GO111MODULE=on go list -mod=readonly -deps -f '#{format_str}' ./..."
         info_output, stderr, status = Cmd.run(go_list_cmd)
         log_errors_with_cmd(go_list_cmd, "Getting the dependencies from go list failed \n\t#{stderr}") unless status.success?
         raise "Command '#{go_list_cmd}' failed to execute" unless status.success?

--- a/spec/lib/license_finder/package_managers/go_modules_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_modules_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     subject { GoModules.new(project_path: Pathname(src_path), logger: logger, log_directory: 'some-directory') }
 
     describe '#current_packages' do
-      let(:go_list_cmd) { "GO111MODULE=on go list -mod=readonly -deps -f '#{go_list_format}' ./..." }
+      let(:go_list_cmd) { "GO111MODULE=on go list -mod=readonly -buildvcs=false -deps -f '#{go_list_format}' ./..." }
 
       before do
         FakeFS.activate!


### PR DESCRIPTION
See why here: https://github.com/pivotal/LicenseFinder/issues/1047

To test just the associated test files, I ran:
```
bundle exec rspec spec/lib/license_finder/package_managers/go_modules_spec.rb features/features/package_managers/go_modules_spec.rb
```

To make a new tag, I ran:
```
git tag v7.2.1d && git push --tag
```

To build a new version of the gem, I ran:
```
gem build license_finder.gemspec
```